### PR TITLE
Preserve untracked local changes before merge in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -213,8 +213,9 @@ update_code() {
     
     # Commit current state
     log_info "Saving current state..."
-    git add -u
-    git commit -am "Before update on ${TIMESTAMP}" > /dev/null 2>&1 || true
+    # Stage tracked + untracked files so local work is preserved before merge
+    git add -A
+    git commit -m "Before update on ${TIMESTAMP}" > /dev/null 2>&1 || true
     
     # Fetch and merge
     log_info "Fetching latest changes..."


### PR DESCRIPTION
### Motivation
- The pre-update safety commit in `update.sh` used `git add -u`, which does not stage untracked files and could leave local untracked work out of the safety commit before merging.

### Description
- Replace `git add -u` + `git commit -am` with `git add -A` + `git commit -m` and add a clarifying inline comment so both tracked and untracked files are staged and committed before performing the merge.

### Testing
- Ran `bash -n update.sh` to verify shell syntax and it succeeded; ran `pytest -q` which reported "no tests ran".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17dbb7049883239fbdcadf9cd9178d)